### PR TITLE
fix(worker): show friendly page for non-POST worker requests

### DIFF
--- a/script/worker.js
+++ b/script/worker.js
@@ -9,6 +9,16 @@ export default {
         return json({ e: "loop detected" }, 508);
       }
 
+      if (request.method !== "POST") {
+        return new Response(
+          "<!DOCTYPE html><html><head><title>Relay Active</title></head>" +
+            '<body style="font-family:sans-serif;max-width:600px;margin:40px auto">' +
+            "<h1>Relay Active</h1><p>Cloudflare Worker routing enabled.</p>" +
+            "</body></html>",
+          { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }
+        );
+      }
+
       const req = await request.json();
 
       if (!req.u) {

--- a/script/worker.js
+++ b/script/worker.js
@@ -13,7 +13,8 @@ export default {
         return new Response(
           "<!DOCTYPE html><html><head><title>Relay Active</title></head>" +
             '<body style="font-family:sans-serif;max-width:600px;margin:40px auto">' +
-            "<h1>Relay Active</h1><p>Cloudflare Worker routing enabled.</p>" +
+            '<h1>Relay <span style="color:#16a34a;font-weight:700">Active</span></h1>' +
+            "<p>Cloudflare Worker routing enabled.</p>" +
             "</body></html>",
           { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }
         );


### PR DESCRIPTION
<img width="399" height="203" alt="Screenshot 2026-05-02 at 19 52 01" src="https://github.com/user-attachments/assets/07dadb70-ceb2-4ab2-967a-ad348219433b" />

---
Hitting the Worker URL in a browser surfaced a `SyntaxError: Unexpected end of JSON input` response, since a GET request has no body for `request.json()` to parse.

Non-POST requests now return a small "Relay Active" HTML page, in line with the Apps Script `doGet` page. The relay POST path and loop-prevention header are unchanged.